### PR TITLE
fix: type for identifyHotjar userId arg

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -68,6 +68,20 @@ describe('Tests useHotjar', () => {
     });
   });
 
+  it('should identifyHotjar for De-identified users', () => {
+    const { result } = renderHook(() => useHotjar());
+    const identifyHotjarSpy = jest.spyOn(result.current, 'identifyHotjar');
+    const { identifyHotjar } = result.current;
+
+    identifyHotjar(null, {
+      ab_test: 'variant-A',
+    });
+
+    expect(identifyHotjarSpy).toHaveBeenCalledWith(null, {
+      ab_test: 'variant-A',
+    });
+  });
+
   it('should stateChange with new relative path', () => {
     const { result } = renderHook(() => useHotjar());
     const stateChangeSpy = jest.spyOn(result.current, 'stateChange');

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface IUseHotjar {
     logCallback?: (...data: unknown[]) => void
   ) => boolean;
   identifyHotjar: (
-    userId: string,
+    userId: string | null,
     userInfo: TUserInfo,
     logCallback?: (...data: unknown[]) => void
   ) => boolean;


### PR DESCRIPTION
Hey!  

I changed the type of `identifyHotjar` `userId` arg following the [documentation](QuentinLuc/react-use-hotjar.git).

Cheers!